### PR TITLE
Explicitly add query parameters to redirect path for the WWT widget.

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -12,6 +12,7 @@ import asyncio
 import os
 from typing import Dict
 from pathlib import Path
+from urllib.parse import urlencode
 
 import tornado.web
 from jupyter_server.base.handlers import JupyterHandler
@@ -195,6 +196,9 @@ class VoilaHandler(JupyterHandler):
     def redirect_to_file(self, path):
         if 'wwt' in path:
             new_path = url_path_join(self.base_url, path.replace('api/kernels', '/'))
+            query_items = [(k, x.decode("utf-8")) for k, v in self.request.query_arguments.items() for x in v]
+            query_string = "?" + urlencode(query_items)
+            new_path += query_string
             self.redirect(new_path)
         else:
             self.redirect(url_path_join(self.base_url, 'voila', 'files', path))


### PR DESCRIPTION
This PR makes the changes that I mentioned earlier on Slack. pywwt communicates with the backend JS using JSON messages, and the backend takes a query parameter that specifies an origin for allowed messages - any other messages are ignored.  pywwt automatically attaches the widget's origin as the allowed source origin.

After the redirect from voila, the query parameters in the widget's URL are no longer present, and so the widget is unwilling to listen to any messages. This PR provides a workaround by modifying redirect_to_file to explicitly add the current query parameters to the redirected path in the WWT-specific case.